### PR TITLE
[Feat] 로그인 API 연동 및 에러 처리

### DIFF
--- a/src/PdfDropzone.tsx
+++ b/src/PdfDropzone.tsx
@@ -1,5 +1,6 @@
 ﻿import { useMemo, useRef, useState, type DragEvent } from "react";
-import { API_BASE, uploadFile, type UploadResult } from "./api/file.api";
+import { uploadFile, type UploadResult } from "./api/file.api";
+import { API_BASE } from "./api/client";
 
 export default function PdfDropzone() {
   const [isDragging, setIsDragging] = useState(false);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,17 +1,31 @@
 export const API_BASE = import.meta.env.VITE_API_BASE;
 
+interface ErrorResponse {
+  message: string;
+  status: number;
+  timestamp: string;
+}
+
 export async function apiFetch<T = any>(
   path: string,
   options?: RequestInit
 ): Promise<T> {
   const res = await fetch(`${API_BASE}${path}`, {
-    credentials: 'include',
     ...options,
+    credentials: 'omit',
   });
 
   if (!res.ok) {
-    const text = await res.text();
-    throw new Error(text || 'API Error');
+    let errorMessage = 'API 오류가 발생했습니다.';
+
+    try {
+      const errorData: ErrorResponse = await res.json();
+      errorMessage = errorData.message || errorMessage;
+    } catch {
+      // JSON 파싱 실패 시 기본 메시지 사용
+    }
+
+    throw new Error(errorMessage);
   }
 
   return res.json();


### PR DESCRIPTION
## 📋 변경 사항
로그인 API 연동 및 에러 처리 UX를 개선했습니다.

## ✨ 구현 내용
- 로그인 성공 시 JWT 토큰 localStorage 저장
- 잘못된 비밀번호/없는 계정 시 에러 메시지 표시
- apiFetch credentials 설정 수정으로 CORS 문제 해결

## 🧪 테스트 방법
1. 프론트 실행 (http://localhost:5173)
2. 올바른 계정 로그인 → 토큰 저장 확인
3. 잘못된 비밀번호 입력 → 에러 메시지 표시

## 🔗 관련 PR
- Related BE PR: feat/auth-login-gaeun
