### PR TITLE
[Feat] 회원가입 이메일 인증 플로우 구현

### DIFF
--- a/src/api/auth.api.ts
+++ b/src/api/auth.api.ts
@@ -5,6 +5,45 @@ interface LoginResponse {
   message?: string;
 }
 
+interface SignupResponse {
+  email: string;
+  message: string;
+}
+
+interface VerificationResponse {
+  message: string;
+}
+
+export const sendVerificationCode = async (email: string): Promise<VerificationResponse> => {
+  return apiFetch<VerificationResponse>('/api/auth/send-verification', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email }),
+  });
+};
+
+export const verifyCode = async (email: string, code: string): Promise<VerificationResponse> => {
+  return apiFetch<VerificationResponse>('/api/auth/verify-code', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, code }),
+  });
+};
+
+export const signup = async (email: string, password: string): Promise<SignupResponse> => {
+  return apiFetch<SignupResponse>('/api/auth/signup', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ email, password }),
+  });
+};
+
 export const login = async (email: string, password: string): Promise<LoginResponse> => {
   return apiFetch<LoginResponse>('/api/auth/login', {
     method: 'POST',


### PR DESCRIPTION
## 📋 변경 사항
회원가입 이메일 인증 플로우를 구현했습니다.

## ✨ 구현 내용
- auth.api.ts에 이메일 인증 관련 API 함수 추가
  - sendVerificationCode() : 인증 코드 요청
  - verifyCode() : 6자리 인증 코드 검증
  - signup() : 회원가입 요청
- Signup.tsx 회원가입 3단계 플로우 구현
  1. 이메일 입력 및 인증 코드 요청
  2. 6자리 인증 코드 입력 및 검증
  3. 비밀번호 입력 및 회원가입
- 이메일 인증 완료 후에만 비밀번호 입력 UI 노출
- 단계별 UI 상태 관리 (인증 전 / 인증 중 / 인증 완료)
- 로딩 상태 및 에러 핸들링 처리

## 🔗 Related
- somshare-BE : 회원가입 및 이메일 인증 API 연동

## 🧪 테스트 방법
1. 회원가입 페이지 접속
2. 이메일 입력 → 인증 코드 요청
3. 인증 코드 입력 및 검증 성공 확인
4. 비밀번호 입력 후 회원가입 완료

## ✅ 체크리스트
- [x] 인증 코드 요청 정상 동작
- [x] 인증 코드 검증 성공/실패 처리
- [x] 이메일 미인증 상태에서 회원가입 차단
- [x] 인증 완료 후 회원가입 가능
